### PR TITLE
Shim `uname` and `pkg-config` for Wasm package build

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -154,13 +154,15 @@ wasm_build <- function(pkg, tarball_path, contrib_bin) {
   webr_version <- getOption("rwasm.webr_version")
   webr_vars <- system.file("webr-vars.mk", package = "rwasm")
   webr_profile <- system.file("webr-profile", package = "rwasm")
+  sys_bin <- system.file("bin", package = "rwasm")
   webr_env <- c(
     paste0("R_PROFILE_USER=", webr_profile),
     paste0("R_MAKEVARS_USER=", webr_vars),
     paste0("WEBR_VERSION=", webr_version),
     paste0("WEBR_ROOT=", webr_root),
-    sprintf("PATH='%s/wasm/bin:%s'", webr_root, Sys.getenv("PATH")),
+    sprintf("PATH='%s:%s/wasm/bin:%s'", sys_bin, webr_root, Sys.getenv("PATH")),
     sprintf("PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root),
+    sprintf("EM_PKG_CONFIG=%s", Sys.which("pkg-config")),
     sprintf("EM_PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root)
   )
 

--- a/inst/bin/pkg-config
+++ b/inst/bin/pkg-config
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# pkg-config wrapper script
+# Based on r-universe-org/macos-cross/R-4.3-x86_64/pkg-config-x86_64.sh
+# Outputs library link flags suitable for static linking with Emscripten
+
+if [ -z "$EM_PKG_CONFIG" ]; then
+    echo "Error: Can't find pkg-config. Set the EM_PKG_CONFIG environment variable when using this wrapper."
+    exit 1
+fi
+
+# Invoke the true `pkg-config` expected by Emscripten's `emconfigure` script
+# Include the `--static` argument to ensure all libraries are included
+PKG_CONFIG_LIBS=$("$EM_PKG_CONFIG" --static "$@")
+
+# With Emscripten, static libraries must be linked only once
+# https://emscripten.org/docs/compiling/Building-Projects.html#troubleshooting
+#
+# Remove duplicates in `pkg-config` output, maintaining the original order,
+# and working from right to left.
+echo "$PKG_CONFIG_LIBS" | xargs -n1 | tail -r | awk '!x[$0]++' | tail -r | xargs

--- a/inst/bin/uname
+++ b/inst/bin/uname
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Fake uname that reports OS as Emscripten
+# Based on r-universe-org/macos-cross/R-4.3-x86_64/uname-x86_64.sh
+#
+# See emscripten-core/emscripten/system/lib/libc/emscripten_syscall_stubs.c for
+# Emscripten's implementation of the `uname` syscall. We try to reasonably match
+# those values here.
+#
+# It is assumed that the Emscripten toolchain is on the path.
+
+flags="$1"
+
+case $flags in
+    "")
+    echo 'Emscripten'
+    ;;
+    -a|-all)
+    # R calls 'uname -a' and requires it to match the host to start up correctly.
+    # Work around this by using the original uname for now.
+    /usr/bin/uname -a
+    ;;
+    -s|--kernel-name)
+    echo 'Emscripten'
+    ;;
+    -n|--nodename)
+    echo 'emscripten'
+    ;;
+    -r|--kernel-release)
+    emcc -dumpversion
+    ;;
+    -v|--kernel-version)
+    echo '#1'
+    ;;
+    -m|--machine)
+    echo 'wasm32'
+    ;;
+    -p|--processor)
+    echo 'wasm32'
+    ;;
+    -i|--hardware-platform)
+    echo 'wasm32'
+    ;;
+    -o|--operating-system)
+    echo 'Emscripten'
+    ;;
+    *)
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
When cross-compiling packages for Wasm, ensure that the `uname` command outputs `"Emscripten"` and the `pkg-config` command outputs a unique list of libraries suitable for static linking.

This should improve compatibility with several R packages' `configure` scripts.

The output for `uname` has been selected based on Emscripten's own implementation of the `uname` syscall. Some details below.

<details>
See <a href="https://github.com/emscripten-core/emscripten/blob/c0c2ca1314672a25699846b4663701bcb6f69cca/system/lib/libc/emscripten_syscall_stubs.c#L49C1-L49C1">`emscripten-core/emscripten/system/lib/libc/emscripten_syscall_stubs.c`</a> for implementation details. With that, the following C code:

```c
#include <stdio.h>
#include <stdlib.h>
#include <errno.h>
#include <sys/utsname.h>

int main(void) {

   struct utsname buffer;

   errno = 0;
   if (uname(&buffer) < 0) {
      perror("uname");
      exit(EXIT_FAILURE);
   }

   printf("system name = %s\n", buffer.sysname);
   printf("node name   = %s\n", buffer.nodename);
   printf("release     = %s\n", buffer.release);
   printf("version     = %s\n", buffer.version);
   printf("machine     = %s\n", buffer.machine);

   return EXIT_SUCCESS;
}
```
when compiled with Emscripten, outputs:

```
$ node main.js
system name = Emscripten
node name   = emscripten
release     = 3.1.47
version     = #1
machine     = wasm32
```
</code>