### PR TITLE
Override LIBS variable

### DIFF
--- a/inst/webr-vars.mk
+++ b/inst/webr-vars.mk
@@ -102,6 +102,7 @@ override SHLIB_LINK = $(SHLIB_LD) $(SHLIB_LDFLAGS) $(LDFLAGS)
 override FOUNDATION_LIBS =
 override LIBINTL =
 
+override LIBS =
 override LIBR =
 override ALL_LIBS = $(PKG_LIBS) $(SHLIB_LIBADD_FILTER) $(LIBR) $(LIBINTL)
 


### PR DESCRIPTION
Prevents packages from accessing the host LIBS. 

This fixes the `unrtf` package.