### PR TITLE
Make CXX17 the default

### DIFF
--- a/inst/webr-vars.mk
+++ b/inst/webr-vars.mk
@@ -64,12 +64,12 @@ CXX14 = em++
 CXX17 = em++
 CXX20 = em++
 CC = emcc
-CXX = em++
+CXX = em++ -std=gnu++17
 FC = $(EMFC)
 
 CFLAGS = $(WASM_CFLAGS)
 CPPFLAGS = $(WASM_CPPFLAGS)
-CXXFLAGS = -std=gnu++11 $(WASM_CXXFLAGS)
+CXXFLAGS = $(WASM_CXXFLAGS)
 CXX98FLAGS = -std=gnu++98 $(WASM_CXXFLAGS)
 CXX11FLAGS = -std=gnu++11 $(WASM_CXXFLAGS)
 CXX14FLAGS = -std=gnu++14 $(WASM_CXXFLAGS)


### PR DESCRIPTION
This matches config of R 4.3 on other platforms, for example on Linux:

```sh
# R CMD config CXX
g++ -std=gnu++17

# R CMD config CXXFLAGS
-g -O2
```

This fixes https://github.com/r-wasm/webr/issues/347. 

Ps: it is unclear to me how [webr-vars.mk](https://github.com/r-wasm/rwasm/blob/main/inst/webr-vars.mk) related to in this package related to [the one in webr](https://github.com/r-wasm/webr/blob/HEAD/packages/webr-vars.mk). Do we fix it there as well?