### PR TITLE
Clarify dependencies argument in add_pkg

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -10,9 +10,7 @@
 #'   source. If `NA`, use a built-in list of references to packages pre-modified
 #'   for use with webR. Defaults to `NULL`, meaning no preference over the usual
 #'   remote sources.
-#' @param dependencies Dependency specification for packages to additionally
-#' build. Defaults to `FALSE`, meaning no additional packages. See
-#' [pkgdepends::as_pkg_dependencies] for details.
+#' @inheritParams add_pkg
 #'
 #' @importFrom pkgdepends new_pkg_download_proposal
 #' @export

--- a/R/repo.R
+++ b/R/repo.R
@@ -77,6 +77,8 @@ add_list <- function(list_file, ...) {
 #'   packages pre-modified for use with webR.
 #' @param dependencies Dependency specification for packages to additionally
 #' add to the repository. Defaults to `FALSE`, meaning no additional packages.
+#' Use `NA` to install only hard dependencies whereas `TRUE` installs all
+#' optional dependencies as well.
 #' See [pkgdepends::as_pkg_dependencies] for details.
 #'
 #' @importFrom dplyr rows_update select

--- a/R/repo.R
+++ b/R/repo.R
@@ -78,8 +78,8 @@ add_list <- function(list_file, ...) {
 #' @param dependencies Dependency specification for packages to additionally
 #' add to the repository. Defaults to `FALSE`, meaning no additional packages.
 #' Use `NA` to install only hard dependencies whereas `TRUE` installs all
-#' optional dependencies as well.
-#' See [pkgdepends::as_pkg_dependencies] for details.
+#' optional dependencies as well. See [pkgdepends::as_pkg_dependencies]
+#' for details.
 #'
 #' @importFrom dplyr rows_update select
 #' @importFrom pkgdepends new_pkg_download_proposal


### PR DESCRIPTION
This PR closes #27 by adding two sentences that describe the two other common values that may be used when specifying dependencies. I believe this will simplify the docs to make it easier for developers to figure out what value to provide without having to do too much man page hopping.