### PR TITLE
Mechanism to override `AC_CHECK_FUNCS` in Autoconf

### DIFF
--- a/inst/configure
+++ b/inst/configure
@@ -9,5 +9,8 @@
 # Additional specific R package fixes
 export STRINGI_CPPFLAGS=-DU_HAVE_MMAP=0
 
+# Override specific Autoconf results for Emscripten environment
+AC_FUNC_OVERRIDES='ac_cv_func_getrandom=no'
+
 # sh is needed for scripts without shebang
-emconfigure sh -c "./configure.orig --build=$BUILD_PLATFORM --host=wasm32-unknown-emscripten"
+emconfigure sh -c "./configure.orig --build=$BUILD_PLATFORM --host=wasm32-unknown-emscripten $AC_FUNC_OVERRIDES"


### PR DESCRIPTION
For R packages using Autoconf, we'll sometimes need to be able to force the result of `AC_CHECK_FUNCS`.

For example, in the `uuid` package Autoconf sets `HAVE_GETRANDOM`. Despite compiling OK, using `getrandom()` at the time of writing fails for R packages compiled using Emscripten, due to a missing symbol. Autoconf missed this because we compile R packages with the `SIDE_MODULE=1` flag. With this flag, Emscripten does not complain about the missing symbols at compile time, but the result fails at runtime.

So, using this mechanism we can force Autoconf to return "no" when checking for `getrandom()`, fixing the issue with `uuid`. We can also extend the mechanism in the future to force other `AC_CHECK_FUNCS` results if we find other R packages with similar runtime issues.

TODO: In the case of non-autoconf-based `configure` scripts we already pass extra arguments `--build` and `--host`, but in principle we should add something so that we don't pass these Autoconf flags to generic `configure` scripts not expecting them.