### PR TITLE
[DRAFT] Fix/support cross-compiling packages depending on RcppParallel & TBB

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -152,6 +152,7 @@ wasm_build <- function(pkg, tarball_path, contrib_bin, compress) {
       break
     }
   }
+ 
 
   # Setup environment for wasm compilation
   webr_root <- getOption("rwasm.webr_root")
@@ -170,6 +171,21 @@ wasm_build <- function(pkg, tarball_path, contrib_bin, compress) {
     sprintf("EM_PKG_CONFIG=%s", Sys.which("pkg-config")),
     sprintf("EM_PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root)
   )
+ 
+  if ("RcppParallel" %in% pak::pkg_deps(pkg)$package) {
+    rcppparallel_tar <- file.path(tmp_dir, "rcppparallel.tgz")
+    download.file(
+      "https://rcppcore.r-universe.dev/bin/emscripten/contrib/4.5/RcppParallel_5.1.10.9000.tgz",
+      rcppparallel_tar,
+      mode = "wb"
+    )
+    untar(rcppparallel_tar)
+    webr_env <- c(
+      webr_env,
+      paste0("TBB_INC=", file.path(tmp_dir, "RcppParallel", "include")),
+      paste0("TBB_LIB=", file.path(tmp_dir, "RcppParallel", "lib"))
+    )
+  }
 
   # Need to use an empty library otherwise R might try to load wasm packages
   # from the library and fail

--- a/R/build.R
+++ b/R/build.R
@@ -172,14 +172,19 @@ wasm_build <- function(pkg, tarball_path, contrib_bin, compress) {
     sprintf("EM_PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root)
   )
  
-  if ("RcppParallel" %in% pak::pkg_deps(pkg)$package) {
-    rcppparallel_tar <- file.path(tmp_dir, "rcppparallel.tgz")
-    download.file(
-      "https://rcppcore.r-universe.dev/bin/emscripten/contrib/4.5/RcppParallel_5.1.10.9000.tgz",
-      rcppparallel_tar,
-      mode = "wb"
-    )
-    untar(rcppparallel_tar)
+  # If package requires linking against RcppParallel & the TBB, download
+  #   a version of RcppParallel compiled for WASM and set include/lib paths
+  #   for the build
+  if ("RcppParallel" %in% pak::pkg_deps(paste0("local::", tarball_path))$package) {
+    if (!dir.exists(file.path(tmp_dir, "RcppParallel"))) {
+      rcppparallel_tar <- file.path(tmp_dir, "rcppparallel.tgz")
+      download.file(
+        "https://rcppcore.r-universe.dev/bin/emscripten/contrib/4.5/RcppParallel_5.1.10.9000.tgz",
+        rcppparallel_tar,
+        mode = "wb"
+      )
+      untar(rcppparallel_tar, exdir = tmp_dir)
+    }
     webr_env <- c(
       webr_env,
       paste0("TBB_INC=", file.path(tmp_dir, "RcppParallel", "include")),


### PR DESCRIPTION
The next version of `RcppParallel` will support [building the bundled TBB for WASM](https://github.com/RcppCore/RcppParallel/pull/237), this PR proposes an approach for linking against the cross-compiled TBB for packages that need to do so.

By downloading a version of `RcppParallel` built for WASM and setting the `TBB_INC` and `TBB_LIB` paths for the cross-compilation, everything builds and links without issue.

At the moment it's just hard-coding a link to the r-universe WASM build for `RcppParallel` - let me know if there's a better or more robust alternative!