### PR TITLE
Add shim for cargo

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -168,6 +168,7 @@ wasm_build <- function(pkg, tarball_path, contrib_bin, compress) {
     paste0("WEBR_ROOT=", webr_root),
     sprintf("PATH='%s:%s/host/bin:%s'", sys_bin, webr_root, Sys.getenv("PATH")),
     sprintf("PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root),
+    sprintf("EM_HOST_CARGO=%s", Sys.which("cargo")),
     sprintf("EM_PKG_CONFIG=%s", Sys.which("pkg-config")),
     sprintf("EM_PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root)
   )

--- a/inst/bin/cargo
+++ b/inst/bin/cargo
@@ -23,6 +23,12 @@ fi
 # back up after the build.
 export CARGO_BUILD_TARGET="wasm32-unknown-emscripten"
 echo "Cross compiling for $CARGO_BUILD_TARGET..."
+
+# If rustup is available, ensure we have the target toolchain
+if rustup --version; then
+  rustup target add $CARGO_BUILD_TARGET
+fi
+
 ${EM_HOST_CARGO} "$@"
 
 if [ "$1" = "build" ] && [ -z "$target" ]; then

--- a/inst/bin/cargo
+++ b/inst/bin/cargo
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+for arg in "$@"; do
+  case "$arg" in
+    "--manifest-path="*)
+    manifest="${arg:16}"
+    ;;
+    "--target="*)
+    target="$arg"
+    ;;
+  esac
+done
+
+# Path to real cargo is provided by R wrapper
+if [ -z "${EM_HOST_CARGO}" ]; then
+  echo "cargo not found"
+  exit 1
+fi
+
+# Make cargo cross-compile by default. Artifacts then land under target/<triple>/
+# instead of target/release where package Makevars expect them, so copy them
+# back up after the build.
+export CARGO_BUILD_TARGET="wasm32-unknown-emscripten"
+echo "Cross compiling for $CARGO_BUILD_TARGET..."
+${EM_HOST_CARGO} "$@"
+
+if [ "$1" = "build" ] && [ -z "$target" ]; then
+  echo "Copying $CARGO_BUILD_TARGET artifacts to target dir"
+  cd "$(dirname ${manifest:-.})/target"
+  cp -Rf "$CARGO_BUILD_TARGET"/* . || true
+fi


### PR DESCRIPTION
I have been testing this for a while on r-universe, and it works well.

We add a shim that makes cargo target `wasm32-unknown-emscripten` by default. Therefore R packages do not need any special casing to support wasm, they just need to invoke the default toolchains in the same way as they do for CC and CXX, etc.

The only thing that makes this a bit tricky: when cross compiling, cargo writes binaries by default to a subdirectory of the output path. So to make the R packages work without changes as they would for a native build, the shim copies the binaries to one directory up, where they would appear normally.