### PR TITLE
Set TBB_INC and TBB_LIB variables for package build (if TBB present)

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -173,6 +173,12 @@ wasm_build <- function(pkg, tarball_path, contrib_bin, compress) {
     sprintf("EM_PKG_CONFIG_PATH=%s/wasm/lib/pkgconfig", webr_root)
   )
 
+  webr_env <- c(
+    webr_env,
+    sprintf("TBB_INC=%s", system2("pkg-config", c("--variable=includedir", "tbb32"), env = webr_env, stdout = TRUE)),
+    sprintf("TBB_LIB=%s", system2("pkg-config", c("--variable=libdir", "tbb32"), env = webr_env, stdout = TRUE))
+  )
+
   # Need to use an empty library otherwise R might try to load wasm packages
   # from the library and fail
   lib_dir <- tempfile()


### PR DESCRIPTION
Looks up and sets the location of the TBB include and lib directories for the build process using the webr `pkg-config`. 

If the TBB has not been installed for webr (e.g., via [this PR](https://github.com/r-wasm/webr/pull/618)), the variables are empty and the build is unaffected.

You can verify that all works (after installing the oneTBB webr libs) via:

```r
pak::pak("RcppCore/RcppParallel")
rwasm::build("andrjohns/StanEstimators")
```